### PR TITLE
Added some basic fixes to get the plugin load on Linux without failures.

### DIFF
--- a/edr/audiofeedback.py
+++ b/edr/audiofeedback.py
@@ -55,3 +55,27 @@ elif platform == 'win32':
 
         def notify(self):
             winsound.PlaySound(self.snd_notify, winsound.SND_ASYNC)
+
+
+elif platform == 'linux':
+    from playsound import playsound
+
+    class AudioFeedback(object):
+
+        def __init__(self):
+            self.snd_warn = utils2to3.abspathmaker(__file__, 'sounds', 'snd_warn.wav')
+            self.snd_notify = utils2to3.abspathmaker(__file__, 'sounds', 'snd_notify.wav')
+
+        def soft(self):
+            self.snd_warn = utils2to3.abspathmaker(__file__, 'sounds', 'snd_warn_soft.wav')
+            self.snd_notify = utils2to3.abspathmaker(__file__, 'sounds', 'snd_notify_soft.wav')
+
+        def loud(self):
+            self.snd_warn = utils2to3.abspathmaker(__file__, 'sounds', 'snd_warn.wav')
+            self.snd_notify = utils2to3.abspathmaker(__file__, 'sounds', 'snd_notify.wav')
+
+        def warn(self):
+            playsound(self.snd_warn)
+
+        def notify(self):
+            playsound(self.snd_notify)

--- a/edr/clippy.py
+++ b/edr/clippy.py
@@ -51,5 +51,8 @@ if os.name == 'nt' or platform.system() == 'Windows':
 elif os.name == 'mac' or platform.system() == 'Darwin':
     clipboard_get = __macGetClipboard
     clipboard_set = __macSetClipboard
-
+elif os.name == 'linux' or platform.system() == 'Linux':
+    clipboard_get = __macGetClipboard
+    clipboard_set = __macSetClipboard
+    
 copy = clipboard_set


### PR DESCRIPTION
I wanted to make use of your plugin on my Linux machine, so made a couple of fixes to things that allow it to load without any issues. I haven't yet properly played the game with EDR installed, but a quick boot up of the game, shows that although of course the overlay doesn't work (I may try to get that working too but with a Linux Overlay app that gamers use for monitoring CPU/GPU Temps and FPS), the material probabilities for the system I jumped to updated in the EDMC window and it did play a sound to alert me that there was something to look at. One caveat is, it does require the installing of an app called 'playsound' in Python, via pip3 install playsound, the upside to this though, is that it's cross platform, so you may even want to remove the system dependencies and just rely on that instead of winsound and nssound... that's entirely up to you of course.