### PR TITLE
Show depleted info

### DIFF
--- a/edr/edrminingstats.py
+++ b/edr/edrminingstats.py
@@ -24,6 +24,7 @@ class EDRMiningStats(object):
         self.current = now
         self.prospected_raw_history = deque(maxlen=8) # 8 max prospector drones
         self.last = {"timestamp": now, "proportion": None, "raw": None, "materials": None}
+        self.depleted = False
 
     def reset(self):
         self.max = 0
@@ -43,13 +44,16 @@ class EDRMiningStats(object):
         self.start = now
         self.current = now
         self.last = {"timestamp": now, "proportion": None, "raw": None, "materials": None}
+        self.depleted = False
 
     def prospected(self, entry):
         if entry.get("event", None) != "ProspectedAsteroid":
             return False
         if entry.get("Remaining", 0) <= 0:
+            self.depleted = True
             return False
 
+        self.depleted = False
         if self.__probably_previously_prospected(entry):
             return False
         

--- a/edr/ingamemsg.py
+++ b/edr/ingamemsg.py
@@ -789,7 +789,10 @@ class InGameMsg(object):
         header = _(u"Mining Stats")
         details = []
         has_stuff = mining_stats.last["proportion"] > 0
-        details.append(_(u"ITM %: {:>6.2f}  [{}/{}; {}]".format(mining_stats.last["proportion"], 1 if has_stuff else 0, mining_stats.last["materials"], mining_stats.last["raw"])))
+        if mining_stats.depleted:
+            details.append(_(u">>>>  DEPLETED  <<<<"))
+        else:
+            details.append(_(u"ITM %: {:>6.2f}  [{}/{}; {}]".format(mining_stats.last["proportion"], 1 if has_stuff else 0, mining_stats.last["materials"], mining_stats.last["raw"])))
         details.append(_(u"MAX %: {:>6.2f}".format(mining_stats.max)))
         details.append(_(u"AVG %: {:>6.2f}".format(mining_stats.mineral_yield_average())))
         details.append(_(u"ITM/H: {:>6.0f} [TGT: {:.0f}]".format(mining_stats.mineral_per_hour(), mining_stats.max_efficiency)))


### PR DESCRIPTION
When a prospector hit a depleted limpet, show a ">>>> DEPLETED <<<" message in place of the composition line, until another prospector hit something that's not depleted.