### PR TITLE
Add limpet reminder on ship changes

### DIFF
--- a/edr/edmodule.py
+++ b/edr/edmodule.py
@@ -66,6 +66,9 @@ class EDModule(object):
     def is_prospector_drone_controller(self):
         return self.cname.startswith('int_dronecontrol_prospector')
 
+    def is_drone_controller(self):
+        return self.cname.startswith('int_dronecontrol')
+
     def __repr__(self):
         return str(self.__dict__)
 

--- a/edr/edvehicles.py
+++ b/edr/edvehicles.py
@@ -451,11 +451,14 @@ class EDVehicle(object):
             for subsystem in self.subsystems:
                 self.subsystem_health(subsystem, 100.0)
 
-    def could_use_limpets(self):
+    def could_use_limpets(self, mining_only=False):
         if self.cargo_capacity <= 0:
             return False
         
-        if not self.is_mining_rig():
+        if mining_only:
+            if not self.is_mining_rig():
+                return False
+        elif not self.has_drone_controller():
             return False
 
         return  self.cargo.how_many("drones") < self.cargo_capacity
@@ -463,6 +466,13 @@ class EDVehicle(object):
     def is_mining_rig(self):
         for slot_name in self.slots:
             if self.slots[slot_name].is_prospector_drone_controller():
+                return True
+        return False
+
+
+    def has_drone_controller(self):
+        for slot_name in self.slots:
+            if self.slots[slot_name].is_drone_controller():
                 return True
         return False
     

--- a/edr/load.py
+++ b/edr/load.py
@@ -288,7 +288,7 @@ def handle_change_events(ed_player, entry):
             if ed_player.mothership.could_use_limpets():
                 limpets = ed_player.mothership.cargo.how_many("drones")
                 capacity = ed_player.mothership.cargo_capacity
-                EDR_CLIENT.notify_with_details(_(U"Restock reminder"), [_(u"Don't forget to restock on limpets before heading out mining."), _(u"Limpets: {}/{}").format(limpets, capacity)])
+                EDR_CLIENT.notify_with_details(_(U"Restock reminder"), [_(u"Don't forget to restock on limpets before heading out."), _(u"Limpets: {}/{}").format(limpets, capacity)])
         elif entry["event"] == "Undocked" and ed_player.mothership.is_mining_rig():
             ed_player.reset_stats()
         outcome["reason"] = "Docking events"
@@ -371,6 +371,11 @@ def handle_lifecycle_events(ed_player, entry, state, from_genesis=False):
     if entry["event"] in ["Loadout"]:
         if ed_player.mothership.id == entry.get("ShipID", None):
             ed_player.mothership.update_from_loadout(entry)
+            ed_player.mothership.update_cargo()
+            if ed_player.mothership.could_use_limpets():
+                limpets = ed_player.mothership.cargo.how_many("drones")
+                capacity = ed_player.mothership.cargo_capacity
+                EDR_CLIENT.notify_with_details(_(U"Restock reminder"), [_(u"Don't forget to restock on limpets before heading out."), _(u"Limpets: {}/{}").format(limpets, capacity)])
             global LAST_KNOWN_SHIP_NAME
             LAST_KNOWN_SHIP_NAME = ed_player.mothership.name
         else:


### PR DESCRIPTION
Also generalize beyond mining (e.g. useful to be reminded of stocking on limpets for a mats scavenger build as well)