### PR TITLE
change edcmoverlay import so it works on Linux

### DIFF
--- a/edr/ingamemsg.py
+++ b/edr/ingamemsg.py
@@ -26,7 +26,7 @@ if sys.platform == "win32":
         sys.path.append(_overlay_dir)
 
 try:
-    import edmcoverlay
+    from EDMCOverlay import edmcoverlay
 except ImportError:
     raise Exception(str(sys.path))
 


### PR DESCRIPTION
I guess on Windows it doesn't matter as it's case insensitive. On Linux this line forces me to load overlay twice

I'm asking you to change the code because among the plugins I use, EDR is the only one that loads it like that
https://github.com/inorton/EDMCHits/blob/master/load.py#L11
https://github.com/aussig/BGS-Tally/blob/develop/bgstally/overlay.py#L8
