### PR TITLE
Refactor: remove unnecessary __future__ imports

### DIFF
--- a/edr/audiofeedback.py
+++ b/edr/audiofeedback.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from sys import platform
 import os.path

--- a/edr/backoff.py
+++ b/edr/backoff.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from edrlog import EDR_LOG
 import random

--- a/edr/clippy.py
+++ b/edr/clippy.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import platform, os
 

--- a/edr/edcargo.py
+++ b/edr/edcargo.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from edrlog import EDR_LOG
 
 

--- a/edr/edcargoreader.py
+++ b/edr/edcargoreader.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 from os.path import join

--- a/edr/edentities.py
+++ b/edr/edentities.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from __future__ import division
 #from builtins import round
 

--- a/edr/edinstance.py
+++ b/edr/edinstance.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from edtime import EDTime
 from edvehicles import EDVehicleFactory

--- a/edr/edmarketreader.py
+++ b/edr/edmarketreader.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 from os.path import join

--- a/edr/edmodule.py
+++ b/edr/edmodule.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 import re

--- a/edr/edmodulesinforeader.py
+++ b/edr/edmodulesinforeader.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 from os.path import join

--- a/edr/edrautoupdater.py
+++ b/edr/edrautoupdater.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import requests
 import zipfile

--- a/edr/edrbodiesofinterest.py
+++ b/edr/edrbodiesofinterest.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import os
 import json

--- a/edr/edrbountyhuntingstats.py
+++ b/edr/edrbountyhuntingstats.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from collections import deque
 from edtime import EDTime

--- a/edr/edrclient.py
+++ b/edr/edrclient.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from copy import deepcopy
 import datetime
 import itertools

--- a/edr/edrcmdrs.py
+++ b/edr/edrcmdrs.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import division
 
 import os
 import pickle

--- a/edr/edrconfig.py
+++ b/edr/edrconfig.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import os
 try:

--- a/edr/edreconbox.py
+++ b/edr/edreconbox.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from edtime import EDTime
 import random

--- a/edr/edrfactions.py
+++ b/edr/edrfactions.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, division
+from __future__ import division
 
 import os
 import pickle

--- a/edr/edrfleet.py
+++ b/edr/edrfleet.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import os
 import sys

--- a/edr/edrfleetcarrier.py
+++ b/edr/edrfleetcarrier.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import copy
 from pickle import TRUE
 import re

--- a/edr/edri18n.py
+++ b/edr/edri18n.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import absolute_import
 
 import gettext
 # import os # 'os' imported but unused Flake8(F401)

--- a/edr/edrinventory.py
+++ b/edr/edrinventory.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import pickle
 import os

--- a/edr/edrlandables.py
+++ b/edr/edrlandables.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import os
 import json

--- a/edr/edrlegalrecords.py
+++ b/edr/edrlegalrecords.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import datetime
 import time

--- a/edr/edrlog.py
+++ b/edr/edrlog.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import logging
 import sys

--- a/edr/edrminingstats.py
+++ b/edr/edrminingstats.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from collections import deque
 from time import time

--- a/edr/edropponents.py
+++ b/edr/edropponents.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import absolute_import, division
+from __future__ import division
 
 import datetime
 import time

--- a/edr/edrrawdepletables.py
+++ b/edr/edrrawdepletables.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 #from builtins import str
 
 import os

--- a/edr/edrrealtime.py
+++ b/edr/edrrealtime.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 
 import requests

--- a/edr/edrresourcefinder.py
+++ b/edr/edrresourcefinder.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 # TODO void opals: Smethells 1, planet 1. Double VO. Or Smei Ti, planet ABC 4.?
 # TODO lower case materials profile

--- a/edr/edrservicecheck.py
+++ b/edr/edrservicecheck.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 from edri18n import _, _c, _edr
 from edrsysstacheck import EDRSystemStationCheck, EDRApexSystemStationCheck

--- a/edr/edrstatefinder.py
+++ b/edr/edrstatefinder.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import threading
 from random import shuffle

--- a/edr/edrtogglingpanel.py
+++ b/edr/edrtogglingpanel.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from subprocess import call
 
 try:

--- a/edr/edsmserver.py
+++ b/edr/edsmserver.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import json
 

--- a/edr/igmconfig.py
+++ b/edr/igmconfig.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import os
 try:

--- a/edr/lrucache.py
+++ b/edr/lrucache.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import collections
 import datetime


### PR DESCRIPTION
Removed `from __future__ import absolute_import` from all python files. This is no longer necessary in Python 3.