### PR TITLE
feat: Add OPSEC feature to avoid reporting certain commanders

### DIFF
--- a/edr/config/user_config_sample.ini
+++ b/edr/config/user_config_sample.ini
@@ -68,4 +68,33 @@ player_webhook =
 ; 2. Copy paste the Webhook URL in the settings below
 ; Note: the webhooks don't have to be different. For instance, one could have their jump_webhook and market_webhook set to the same channel.
 jump_webhook = 
-market_webhook = 
+market_webhook =
+
+[opsec]
+; This section is used to avoid reporting intel on certain commanders.
+; This is useful if you are concerned about OPSEC (Operational Security).
+; E.g. you don't want to report on commanders aligned with your power.
+;
+; By default, EDR will not report on commanders that are:
+; - in your wing
+; - in your crew
+; - in your squadron
+; - pledged to your power
+;
+; You can disable this feature by setting 'enabled' to no.
+; You can also customize the rules by setting the corresponding options to no.
+;
+enabled = yes
+wing = yes
+crew = yes
+squadron = yes
+power = yes
+;
+;
+; You can also specify a list of commanders and powers to never report on.
+; These are comma-separated lists.
+; e.g. never_report_cmdrs = LeKeno, John Doe
+; e.g. never_report_powers = Zachary Hudson, Felicia Winters
+;
+never_report_cmdrs =
+never_report_powers =

--- a/edr/edrclient.py
+++ b/edr/edrclient.py
@@ -16,7 +16,7 @@ import myNotebook as notebook
 from config import config
 
 from edrfleetcarrier import EDRFleetCarrier
-from edrconfig import EDRConfig
+from edrconfig import EDRConfig, EDRUserConfig
 from lrucache import LRUCache
 from edentities import EDFineOrBounty
 from edsitu import EDPlanetaryLocation, EDLocation
@@ -145,7 +145,8 @@ class EDRClient(object):
         self.edrsystems = EDRSystems(self.server, self.edsm_server, self.edrfactions)
         self.edrresourcefinder = EDRResourceFinder(self.edrsystems, self.edrfactions)
         self.edrboi = EDRBodiesOfInterest()
-        self.edrcmdrs = EDRCmdrs(self.server)
+        user_config = EDRUserConfig()
+        self.edrcmdrs = EDRCmdrs(self.server, user_config.opsec_config())
         self.edropponents = {
             EDROpponents.OUTLAWS: EDROpponents(self.server, EDROpponents.OUTLAWS, self._realtime_callback),
             EDROpponents.ENEMIES: EDROpponents(self.server, EDROpponents.ENEMIES, self._realtime_callback),

--- a/edr/edrcmdrprofile.py
+++ b/edr/edrcmdrprofile.py
@@ -452,3 +452,27 @@ class EDRCmdrProfile(object):
             result += u"✪PP {} ".format(", ".join(powerplay_parts))
 
         return result
+
+    def is_opsec(self, player, opsec_config):
+        if not opsec_config or not opsec_config.opsec_enabled:
+            return False
+
+        if opsec_config.is_never_report_cmdr(self.name):
+            return True
+
+        if opsec_config.is_never_report_power(self.powerplay):
+            return True
+
+        if opsec_config.power and self.powerplay and player.power and self.powerplay == player.power:
+            return True
+
+        if opsec_config.squadron and self.squadron_id and player.squadron and self.squadron_id == player.squadron.inara_id:
+            return True
+
+        if opsec_config.wing and player.is_wingmate(self.name):
+            return True
+
+        if opsec_config.crew and player.is_crewmate(self.name):
+            return True
+
+        return False

--- a/edr/edrcmdrs.py
+++ b/edr/edrcmdrs.py
@@ -16,9 +16,10 @@ class EDRCmdrs(object):
     EDR_INARA_CACHE = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'cache', 'inara.v7.p')
     EDR_SQDRDEX_CACHE = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'cache', 'sqdrdex.v2.p')
 
-    def __init__(self, edrserver):
+    def __init__(self, edrserver, opsec_config=None):
         self.server = edrserver
         self._player = EDPlayerOne()
+        self.opsec_config = opsec_config
         self.heartbeat_timestamp = None
  
         edr_config = EDRConfig()
@@ -121,9 +122,22 @@ class EDRCmdrs(object):
             EDR_LOG.log(u"Cmdr {cmdr} is in the EDR cache with id={cid}".format(cmdr=cmdr_name,
                                                                            cid=profile.cid if profile else 'N/A'),
                        "DEBUG")
-            return profile
+            if profile and self.opsec_config:
+                if profile.is_opsec(self.player, self.opsec_config):
+                    EDR_LOG.log(u"Cmdr {cmdr} is opsec, not reporting.".format(cmdr=cmdr_name), "INFO")
+                    return profile
+            elif not profile:
+                return profile
 
-        profile = self.server.cmdr(cmdr_name, autocreate)
+        effective_autocreate = autocreate
+        if self.opsec_config and autocreate:
+            # Check Inara for squadron and power info
+            inara_profile = self.__inara_cmdr(cmdr_name, True)
+            if inara_profile and inara_profile.is_opsec(self.player, self.opsec_config):
+                EDR_LOG.log(u"Cmdr {cmdr} is opsec, not reporting.".format(cmdr=cmdr_name), "INFO")
+                effective_autocreate = False
+
+        profile = self.server.cmdr(cmdr_name, effective_autocreate)
 
         if not profile:
             self.cmdrs_cache.set(cmdr_name.lower(), None)

--- a/edr/edrconfig.py
+++ b/edr/edrconfig.py
@@ -1,6 +1,7 @@
 
 import os
 import configparser as cp
+from edropsec import EDROpsecConfig
 
 
 class EDRUserConfig(object):
@@ -10,6 +11,11 @@ class EDRUserConfig(object):
             self.config.read(os.path.join(os.path.abspath(os.path.dirname(__file__)), config_file))
         except:
             self.config = None
+
+    def opsec_config(self):
+        if self.config and self.config.has_section('opsec'):
+            return EDROpsecConfig(self.config)
+        return None
 
     def discord_webhook_for_comms(self, channel, incoming=True):
         if self.config:

--- a/edr/edropsec.py
+++ b/edr/edropsec.py
@@ -1,0 +1,19 @@
+class EDROpsecConfig(object):
+    def __init__(self, user_config):
+        self.opsec_enabled = user_config.getboolean('opsec', 'enabled') if user_config.has_option('opsec', 'enabled') else True
+        self.wing = user_config.getboolean('opsec', 'wing') if user_config.has_option('opsec', 'wing') else True
+        self.crew = user_config.getboolean('opsec', 'crew') if user_config.has_option('opsec', 'crew') else True
+        self.squadron = user_config.getboolean('opsec', 'squadron') if user_config.has_option('opsec', 'squadron') else True
+        self.power = user_config.getboolean('opsec', 'power') if user_config.has_option('opsec', 'power') else True
+
+        never_report_cmdrs = user_config.get('opsec', 'never_report_cmdrs') if user_config.has_option('opsec', 'never_report_cmdrs') else ''
+        self.never_report_cmdrs = set(val.strip() for val in never_report_cmdrs.split(',')) if never_report_cmdrs else set()
+
+        never_report_powers = user_config.get('opsec', 'never_report_powers') if user_config.has_option('opsec', 'never_report_powers') else ''
+        self.never_report_powers = set(val.strip() for val in never_report_powers.split(',')) if never_report_powers else set()
+
+    def is_never_report_cmdr(self, cmdr_name):
+        return cmdr_name in self.never_report_cmdrs
+
+    def is_never_report_power(self, power_name):
+        return power_name in self.never_report_powers


### PR DESCRIPTION
This feature introduces an OPSEC (Operational Security) option to prevent reporting intel on certain commanders to EDR Central.

By default, EDR will not report on commanders that are:
- in the same wing
- in the same crew
- in the same squadron
- pledged to the same power

This feature is enabled by default but can be disabled or customized via a new `[opsec]` section in the `user_config.ini` file.

Advanced customization is also available, allowing users to specify a list of commanders or powers to never report on.

The implementation ensures that while reporting is prevented, the user can still see the intel profile of all commanders.