### PR TITLE
feat: Implement gesture-based POI navigation

### DIFF
--- a/edr/edrclient.py
+++ b/edr/edrclient.py
@@ -3218,13 +3218,17 @@ class EDRClient(object):
         elif action == "wave":
             pass
         elif action == "agree":
-            pass
+            self.next_custom_poi()
+            self.__notify(_("EDR Navigation (thumb up gesture)"), [_("Switched to next POI.")])
         elif action == "disagree":
-            pass
+            self.previous_custom_poi()
+            self.__notify(_("EDR Navigation (thumb down gesture)"), [_("Switched to previous POI.")])
         elif action == "go":
             pass
         elif action == "stop":
-            pass
+            self.player.planetary_destination = None
+            self.clear_current_custom_poi()
+            self.__notify(_("EDR Navigation (stop gesture)"), [_("Cleared current POI.")])
         elif action == "applaud":
             pass
         elif action == "salute":


### PR DESCRIPTION
This commit implements the following features:
- The "stop" gesture now clears the current custom POI.
- The "thumb up" (agree) gesture now selects the next custom POI.
- The "thumb down" (disagree) gesture now selects the previous custom POI.

These features were requested in issue #538.