### PR TITLE
Remove redundant calls to random.seed()

### DIFF
--- a/edr/edrplanetfinder.py
+++ b/edr/edrplanetfinder.py
@@ -69,7 +69,6 @@ class EDRPlanetFinder(threading.Thread):
             return candidates
 
         if self.shuffle_systems:
-            seed() # TODO should no longer be necessary
             EDR_LOG.log("Nearby: shuffling systems", "DEBUG")
             shuffle(systems)
 
@@ -182,7 +181,6 @@ class EDRPlanetFinder(threading.Thread):
             return None
 
         if self.shuffle_planets:
-            seed() # TODO should no longer be necessary
             EDR_LOG.log("Nearby: shuffling bodies", "DEBUG")
             shuffle(all_bodies)
 


### PR DESCRIPTION
The `random.seed()` calls in `edr/edrplanetfinder.py` are redundant because `random.shuffle()` automatically uses a random seed if one is not provided. This change removes the unnecessary calls, simplifying the code and addressing the TODO comment.