### PR TITLE
feat: Make account link clickable in settings

### DIFF
--- a/edr/edrclientui.py
+++ b/edr/edrclientui.py
@@ -72,8 +72,14 @@ class EDRClientUI(object):
         notebook.Label(frame, text=_(u'Credentials')).grid(padx=10, sticky=tk.W)
         ttk.Separator(frame, orient=tk.HORIZONTAL).grid(columnspan=2, padx=10, pady=2, sticky=tk.EW)
         # Translators: this is shown in the preferences panel
-        cred_label = notebook.Label(frame, text=_(u'Log in with your EDR account for full access (https://edrecon.com/account)'))
-        cred_label.grid(padx=10, columnspan=2, sticky=tk.W)
+        cred_frame = notebook.Frame(frame)
+        cred_label_text = _(u'Log in with your EDR account for full access. {}')
+        cred_label = notebook.Label(cred_frame, text=cred_label_text.format(""))
+        cred_label.pack(side=tk.LEFT)
+        # Translators: this is shown in the preferences panel, after a sentence saying "Log in with your EDR account for full access."
+        apply_text = _(u"Apply for an account.")
+        ttkHyperlinkLabel.HyperlinkLabel(cred_frame, text=apply_text, background=notebook.Label().cget('background'), url="https://edrecon.com/account", underline=True).pack(side=tk.LEFT)
+        cred_frame.grid(padx=10, columnspan=2, sticky=tk.W)
 
         notebook.Label(frame, text=_(u"Email")).grid(padx=10, row=11, sticky=tk.W)
         notebook.EntryMenu(frame, textvariable=self.edr_client._email).grid(padx=10, row=11,


### PR DESCRIPTION
This commit improves the settings UI by making the link to apply for an EDR account clickable. It also improves the description of the link to make it easier to understand for users.

The previous implementation used a simple label to display the URL, which was not clickable. This change replaces the label with a `ttkHyperlinkLabel` to make the link interactive. The text has also been updated to be more descriptive and user-friendly.