### PR TITLE
Fix TclError by using grid instead of pack in edrclientui.py

### DIFF
--- a/edr/edrclientui.py
+++ b/edr/edrclientui.py
@@ -75,10 +75,10 @@ class EDRClientUI(object):
         cred_frame = notebook.Frame(frame)
         cred_label_text = _(u'Log in with your EDR account for full access. {}')
         cred_label = notebook.Label(cred_frame, text=cred_label_text.format(""))
-        cred_label.pack(side=tk.LEFT)
-        # Translators: this is shown in the preferences panel, after a sentence saying "Log in with your EDR account for full access."
+        cred_label.grid(row=0, column=0, sticky=tk.W)
+        # Translators: this is shown in the preferences panel, after a sentence saying "Log in with your EE.DR account for full access."
         apply_text = _(u"Apply for an account.")
-        ttkHyperlinkLabel.HyperlinkLabel(cred_frame, text=apply_text, background=notebook.Label().cget('background'), url="https://edrecon.com/account", underline=True).pack(side=tk.LEFT)
+        ttkHyperlinkLabel.HyperlinkLabel(cred_frame, text=apply_text, background=notebook.Label().cget('background'), url="https://edrecon.com/account", underline=True).grid(row=0, column=1, sticky=tk.W)
         cred_frame.grid(padx=10, columnspan=2, sticky=tk.W)
 
         notebook.Label(frame, text=_(u"Email")).grid(padx=10, row=11, sticky=tk.W)


### PR DESCRIPTION
This commit resolves a `_tkinter.TclError: cannot use geometry manager pack inside ... which already has slaves managed by grid`.

The error was caused by mixing `pack` and `grid` geometry managers within the same Tkinter frame. The fix replaces the `pack()` calls with `grid()` to ensure consistent use of the grid geometry manager within the `cred_frame` of the preferences UI.