### PR TITLE
fix: Gracefully handle EDSM API failures for systems_within_radius

### DIFF
--- a/edr/edrparkingsystemfinder.py
+++ b/edr/edrparkingsystemfinder.py
@@ -43,7 +43,11 @@ class EDRParkingSystemFinder(threading.Thread):
                 return candidate
         
         systems = self.edr_systems.systems_within_radius(self.star_system, self.radius)
-        if not systems:
+        if systems is None:
+            return None
+
+        if systems is False:
+            EDR_LOG.log(u"Couldn't get systems within radius of {}: EDSM API issue?".format(self.star_system), "ERROR")
             return None
 
         sorted_systems = sorted(systems, key=lambda s: s['distance'])

--- a/edr/edrplanetfinder.py
+++ b/edr/edrplanetfinder.py
@@ -65,7 +65,11 @@ class EDRPlanetFinder(threading.Thread):
                 return candidates["prime"]
                
         systems = self.edr_systems.systems_within_radius(self.star_system, self.radius)
-        if not systems:
+        if systems is None:
+            return candidates
+
+        if systems is False:
+            self.checker.preliminary_msg = _(u"Couldn't get systems within radius of {}: EDSM API is probably having issues.").format(self.star_system)
             return candidates
 
         if self.shuffle_systems:

--- a/edr/edrservicefinder.py
+++ b/edr/edrservicefinder.py
@@ -73,8 +73,12 @@ class EDRServiceFinder(threading.Thread):
                 return candidates["prime"]
                
         systems = self.edr_systems.systems_within_radius(self.star_system, self.radius)
-        if not systems:
-            return candidates["prime"] or candidates["alt"]  
+        if systems is None:
+            return candidates["prime"] or candidates["alt"]
+
+        if systems is False:
+            self.checker.preliminary_msg = _(u"Couldn't get systems within radius of {}: EDSM API is probably having issues.").format(self.star_system)
+            return None
 
         if self.shuffle_systems:
             shuffle(systems)

--- a/edr/edrsettlementfinder.py
+++ b/edr/edrsettlementfinder.py
@@ -77,8 +77,12 @@ class EDRSettlementFinder(threading.Thread):
                 return candidates["prime"]
                
         systems = self.edr_systems.systems_within_radius(self.star_system, self.radius)
-        if not systems:
+        if systems is None:
             return candidates
+
+        if systems is False:
+            self.checker.preliminary_msg = _(u"Couldn't get systems within radius of {}: EDSM API is probably having issues.").format(self.star_system)
+            return None
 
         if self.shuffle_systems:
             shuffle(systems)

--- a/edr/edrstatefinder.py
+++ b/edr/edrstatefinder.py
@@ -51,9 +51,13 @@ class EDRStateFinder(threading.Thread):
                     return (best_system_so_far, best_grade_so_far)
 
         systems = self.edr_systems.systems_within_radius(self.star_system, self.radius)
-        if not systems:
+        if systems is None:
             return (None, None)
-        
+
+        if systems is False:
+            self.checker.preliminary_msg = _(u"Couldn't get systems within radius of {}: EDSM API is probably having issues.").format(self.star_system)
+            return (None, None)
+
         (best_system_so_far, best_grade_so_far) = self.__search(systems, best_system_so_far, best_grade_so_far)
         if not best_system_so_far:
             shuffle(systems)

--- a/edr/edsmserver.py
+++ b/edr/edsmserver.py
@@ -40,6 +40,10 @@ class EDSMServer(object):
         endpoint = "{}/api-v1/sphere-systems".format(self.EDSM_SERVER)
         results = self.__get(endpoint, params) 
         
+        if not isinstance(results, list):
+            EDR_LOG.log(u"Systems within radius is not a list, EDSM API may be having issues. Response: {}".format(results), "WARNING")
+            return None
+
         if not results:
             EDR_LOG.log(u"Empty systems within radius.", "INFO")
             return []


### PR DESCRIPTION
The EDSM API for `systems_within_radius` can return an empty dictionary `{}` on failure. This change introduces several improvements to handle this situation:

- The `systems_within_radius` function in `edsmserver.py` now detects non-list responses and returns `None` to indicate an error.
- A session-level, in-memory blocklist has been added to `EDRSystems`. If an API call fails, the query is added to this blocklist to prevent repeated calls to the failing endpoint for the duration of the session. This avoids polluting the persistent cache with failure states.
- All finders that call `systems_within_radius` have been updated to check for a `False` return value, which now signals an API failure.
- When a failure is detected, the finders will now display a user-friendly message indicating a temporary issue with the EDSM API.