### PR TITLE
Fix: Prevent status bar from resizing UI

### DIFF
--- a/edr/edrtogglingpanel.py
+++ b/edr/edrtogglingpanel.py
@@ -73,6 +73,7 @@ class ToggledFrame(tk.Frame):
         self.status_frame.configure(background=bg)
         self.status_frame.grid(row=0, column=0, sticky="ew")
         self.grid_columnconfigure(0, weight=1)
+        self.status_frame.grid_propagate(False)
         
         self.sub_frame = tk.Frame(self, relief="flat", borderwidth=0)
         self.sub_frame.configure(background=bg)


### PR DESCRIPTION
The status bar was causing the entire UI to resize when its content changed. This was because the `status_frame` was propagating its geometry to its parent.

This commit fixes the issue by adding `self.status_frame.grid_propagate(False)` to the `__init__` method of the `ToggledFrame` class. This prevents the `status_frame` from controlling the size of its parent, allowing the UI to resize correctly.